### PR TITLE
Fix LUFA error when compiling doce

### DIFF
--- a/keyboards/doce/rules.mk
+++ b/keyboards/doce/rules.mk
@@ -1,5 +1,9 @@
 # MCU name
 MCU = atmega32u4
+ARCH = AVR8
+F_CPU = 16000000
+F_USB = $(F_CPU)
+OPT_DEFS += -DINTERRUPT_CONTROL_ENDPOINT
 
 # Bootloader selection
 #   Teensy       halfkay


### PR DESCRIPTION
Added options to rules.mk as listed in https://github.com/qmk/qmk_firmware/blob/master/docs/config_options.md#avr-mcu-options

Without these I cannot compile when doing make doce:default. With these additional options I was able to compile and flash.